### PR TITLE
Fix Symbolics.MakeTuple UndefVarError with latest Symbolics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReversePropagation"
 uuid = "527681c1-8309-4d3f-8790-caf822a419ba"
 authors = ["David P. Sanders <dpsanders@gmail.com> and contributors"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/src/ReversePropagation.jl
+++ b/src/ReversePropagation.jl
@@ -7,6 +7,7 @@ import Symbolics: toexpr, variable
 using SymbolicUtils
 using SymbolicUtils: Sym, Term
 using SymbolicUtils.Rewriters
+using SymbolicUtils.Code: MakeTuple
 
 using Symbolics
 using Symbolics: value,

--- a/src/reverse_diff.jl
+++ b/src/reverse_diff.jl
@@ -226,9 +226,9 @@ function gradient(ex::Num, vars)
 
     code, final_var, gradient_vars = gradient_expr(ex, vars)
 
-    input_vars = toexpr(Symbolics.MakeTuple(vars))
+    input_vars = toexpr(MakeTuple(vars))
     final = toexpr(final_var)
-    gradient = toexpr(Symbolics.MakeTuple(gradient_vars))
+    gradient = toexpr(MakeTuple(gradient_vars))
 
     full_code = quote
         ($input_vars, ) -> begin

--- a/src/reverse_icp.jl
+++ b/src/reverse_icp.jl
@@ -38,7 +38,7 @@ function rev(eq::Assignment, params)
 
     reverse = rev(op(eq), lhs(eq), vars...)
 
-    return Assignment(Symbolics.MakeTuple(return_vars), reverse)
+    return Assignment(MakeTuple(return_vars), reverse)
 
 end
 
@@ -126,7 +126,7 @@ end
 
 # code
 
-Symbolics.toexpr(t::Tuple) = Symbolics.toexpr(Symbolics.MakeTuple(t))
+Symbolics.toexpr(t::Tuple) = Symbolics.toexpr(MakeTuple(t))
 
 # vars = @variables x, y
 
@@ -171,13 +171,13 @@ function forward_backward_contractor(ex, vars, params=[])
 
     code, final_var, constraint_var = forward_backward_expr(ex, vars, params)
 
-    input_vars = toexpr(Symbolics.MakeTuple(vars))
+    input_vars = toexpr(MakeTuple(vars))
     final = toexpr(final_var)
 
     constraint = toexpr(constraint_var)
 
     if !isempty(params)
-        params_tuple = toexpr(Symbolics.MakeTuple(params))
+        params_tuple = toexpr(MakeTuple(params))
 
         function_code =
             quote


### PR DESCRIPTION
## Summary
- `Symbolics.jl` switched its `SymbolicUtils.Code` import from a blanket `using SymbolicUtils.Code` to a selective `using SymbolicUtils.Code: Assignment, AtIndex, DestructuredArgs, Func, Let, LiteralExpr, MakeArray, SetArray, SpawnFetch` list that omits `MakeTuple`. As a result `Symbolics.MakeTuple` no longer resolves against recent Symbolics/SymbolicUtils releases (reproduced with Symbolics 7.39.0 / SymbolicUtils 4.46.2).
- Import `MakeTuple` directly from `SymbolicUtils.Code` in `ReversePropagation.jl` and use the bare name at all call sites instead of the (now broken) `Symbolics.MakeTuple` qualification.
- Bump the package patch version to 0.4.2.

Fixes #86

## Test plan
- [x] Reproduced the exact `UndefVarError: MakeTuple not defined in Symbolics` failure from #86 against Symbolics 7.39.0 / SymbolicUtils 4.46.2 before the fix.
- [x] Confirmed `ReversePropagation.gradient` runs successfully with the fix, against the same Symbolics/SymbolicUtils versions.
- [x] `Pkg.test()` passes (9/9) with the fix against Symbolics 7.39.0 / SymbolicUtils 4.46.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)